### PR TITLE
ci: run CI on every pull request so required checks can report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,6 @@ on:
       - "clippy.toml"
   pull_request:
     branches: [main, "feat/*"]
-    paths:
-      - "**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "build.rs"
-      - "benches/**"
-      - "examples/**"
-      - "tests/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/nightly.yml"
-      - "rustfmt.toml"
-      - "clippy.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
**This repository currently cannot merge any pull request that does not touch Rust.**

Three checks are required by branch protection:

- `🏗️ Architecture Compliance`
- `⚡ Benchmark Guardrail`
- `🔨 Build Check (macos-latest)`

All three live in `ci.yml`, whose `pull_request` trigger is filtered to `**/*.rs`, `Cargo.toml`, `Cargo.lock` and friends. A pull request touching anything else — documentation, `dependabot.yml`, a workflow other than `ci.yml` — runs none of them. Required checks that never report are permanently pending, so the pull request is blocked forever. `enforce_admins` is on, so an admin merge cannot bypass it either.

Found because a one-line `.github/dependabot.yml` change could not be merged; the only check that ran was Dependabot's own config validation.

## The fix

Remove the `paths:` filter from the **`pull_request`** trigger only. The `push` filter is untouched, so branch pushes still skip CI for unrelated changes.

## The alternative, and why not

Dropping the three checks from branch protection would also have unblocked it — and would have ungated every Rust change in the repository. That is the wrong trade. Running Rust CI on a config-only pull request costs a few minutes; not being able to merge costs more.

Three sibling repositories had the same class of problem and were fixed the other way, because there the required context named a job that **does not exist** (`rlg`: `cargo run --example`) or one that only runs on tag/main and so is not a pull-request gate at all (`pain001-lsp`, `bankstatementparser-lsp`: `Build (and publish on tag/main)`). Here the jobs are real and do gate something, so the trigger is what needed fixing, not the requirement.